### PR TITLE
TodoList 테스트 코드 작성

### DIFF
--- a/leo/components/TodoAddForm/index.leo.test.tsx
+++ b/leo/components/TodoAddForm/index.leo.test.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
+import TodoAddForm from './index';
+
+export function renderTodoAddForm() {
+  const ENTER_KEY = '[Enter]';
+  const onSubmit = jest.fn();
+
+  const result = render(<TodoAddForm addTodo={onSubmit} />);
+
+  const AddInput = () => result.getByTestId('addInput');
+  const AddButton = () => result.getByTestId('addButton');
+
+  async function changeAddInput(text: string) {
+    await userEvent.type(AddInput(), text);
+  }
+  async function clickAddButton() {
+    await userEvent.click(AddButton());
+  }
+
+  return {
+    ENTER_KEY,
+    onSubmit,
+    result,
+    AddInput,
+    AddButton,
+    changeAddInput,
+    clickAddButton
+  }
+}
+
+describe('<TodoHeader />', () => {
+  test('초기 렌더링 시 화면에 올바르게 노출된다.', () => {
+    const { AddInput, AddButton } = renderTodoAddForm();
+
+    expect(AddInput()).toHaveValue('');
+    expect(AddButton()).toBeInTheDocument();
+  });
+
+  test('input에 값을 입력하고 버튼 클릭 시 이벤트가 호출된다.', async () => {
+    const { AddInput, changeAddInput, clickAddButton, onSubmit } = renderTodoAddForm();
+    const text = 'Study Next.js';
+
+    await changeAddInput(text);
+    await clickAddButton();
+
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      task: text,
+      completed: false
+    }));
+    expect(AddInput()).toHaveValue('');
+  });
+
+  test('input에 값을 입력하고 Enter 시 이벤트가 호출된다.', async () => {
+    const { AddInput, changeAddInput, onSubmit, ENTER_KEY } = renderTodoAddForm();
+    const text = 'Study Next.js';
+
+    await changeAddInput(text);
+    await changeAddInput(ENTER_KEY);
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+      task: text,
+      completed: false
+    }));
+    expect(AddInput()).toHaveValue('');
+  });
+});

--- a/leo/components/TodoAddForm/index.leo.test.tsx
+++ b/leo/components/TodoAddForm/index.leo.test.tsx
@@ -31,7 +31,7 @@ export function renderTodoAddForm() {
   }
 }
 
-describe('<TodoHeader />', () => {
+describe('<TodoAddForm />', () => {
   test('초기 렌더링 시 화면에 올바르게 노출된다.', () => {
     const { AddInput, AddButton } = renderTodoAddForm();
 
@@ -39,7 +39,7 @@ describe('<TodoHeader />', () => {
     expect(AddButton()).toBeInTheDocument();
   });
 
-  test('input에 값을 입력하고 버튼 클릭 시 이벤트가 호출된다.', async () => {
+  test('Add Input에 값을 입력하고 Add 버튼 클릭 시 이벤트가 호출된다.', async () => {
     const { AddInput, changeAddInput, clickAddButton, onSubmit } = renderTodoAddForm();
     const text = 'Study Next.js';
 
@@ -53,12 +53,13 @@ describe('<TodoHeader />', () => {
     expect(AddInput()).toHaveValue('');
   });
 
-  test('input에 값을 입력하고 Enter 시 이벤트가 호출된다.', async () => {
+  test('Add Input에 값을 입력하고 Enter 시 이벤트가 호출된다.', async () => {
     const { AddInput, changeAddInput, onSubmit, ENTER_KEY } = renderTodoAddForm();
     const text = 'Study Next.js';
 
     await changeAddInput(text);
     await changeAddInput(ENTER_KEY);
+
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       task: text,
       completed: false

--- a/leo/components/TodoAddForm/index.tsx
+++ b/leo/components/TodoAddForm/index.tsx
@@ -24,8 +24,8 @@ const TodoAddForm = ({ addTodo }: Props) => {
   return (
     <S.AddTodoForm>
       <form onSubmit={handleSubmit}>
-        <input type='text' value={addTask} onChange={handleInput} placeholder='New Todo' />
-        <button>Add Todo</button>
+        <input data-testid='addInput' type='text' value={addTask} onChange={handleInput} placeholder='New Todo' />
+        <button data-testid='addButton'>Add Todo</button>
       </form>
     </S.AddTodoForm>
   );

--- a/leo/components/TodoHeader/index.leo.test.tsx
+++ b/leo/components/TodoHeader/index.leo.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import TodoHeader from './index';
+
+export function renderTodoHeader() {
+  const totalNumber = 5;
+  const completedTotalNumber = 3;
+  const result = render(<TodoHeader totalNumber={totalNumber} completedTotalNumber={completedTotalNumber} />);
+
+  const Title = () => result.getByTestId('title');
+  const Count = () => result.getByTestId('count');
+  const getCountText = (total: number, completed: number) => `총 ${total}개 중 ${completed}개 완료`;
+
+  return {
+    totalNumber,
+    completedTotalNumber,
+    result,
+    Title,
+    Count,
+    getCountText,
+  }
+}
+
+describe('<TodoHeader />', () => {
+  test('초기 렌더링 시 화면에 올바르게 노출된다. ', () => {
+    const { Title, Count, getCountText, totalNumber, completedTotalNumber } = renderTodoHeader();
+
+    expect(Title()).toBeInTheDocument();
+    expect(Count()).toHaveTextContent(getCountText(totalNumber,completedTotalNumber));
+  });
+});

--- a/leo/components/TodoHeader/index.test.tsx
+++ b/leo/components/TodoHeader/index.test.tsx
@@ -1,8 +1,0 @@
-import React from "react";
-import '@testing-library/jest-dom';
-
-describe('TodoHeader', () => {
-  it('render', () => {
-    //test
-  });
-});

--- a/leo/components/TodoHeader/index.tsx
+++ b/leo/components/TodoHeader/index.tsx
@@ -5,15 +5,15 @@ interface Props {
   completedTotalNumber: number;
 }
 
-const Header = ({ totalNumber, completedTotalNumber }: Props) => {
+const TodoHeader = ({ totalNumber, completedTotalNumber }: Props) => {
   return (
     <S.TodoHeader>
-      <h1>Todo App</h1>
-      <p>
+      <h1 data-testid='title'>Todo App</h1>
+      <p data-testid='count'>
         총 {totalNumber}개 중 {completedTotalNumber}개 완료
       </p>
     </S.TodoHeader>
   );
 };
 
-export default Header;
+export default TodoHeader;

--- a/leo/components/TodoItem/index.leo.test.tsx
+++ b/leo/components/TodoItem/index.leo.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
+import TodoItem from './index';
+
+export function renderTodoItem() {
+  const completeIcon = 'xi-check-square';
+  const incompleteIcon = 'xi-checkbox-blank';
+  const todoData = { idx: 'one', task: 'Study JS', completed: false };
+
+  const onDelete = jest.fn();
+  const onToggle = jest.fn();
+  const onUpdate = jest.fn();
+
+  const result = render(<TodoItem data={todoData} deleteTodo={onDelete} toggleTodo={onToggle} updateTodo={onUpdate} />);
+
+  const Todo = () => result.getByTestId('todo');
+  const TodoIcon = () => result.getByTestId('todoIcon');
+  const TodoText = () => result.getByTestId('todoText');
+  const TodoEditButton = () => result.getByTestId('todoEditButton');
+  const TodoDeleteButton = () => result.getByTestId('todoDeleteButton');
+
+  const TodoEdit = () => result.getByTestId('todoEdit');
+  const TodoEditInput = () => result.getByTestId('todoEditInput');
+  const TodoEditSaveButton = () => result.getByTestId('todoEditSaveButton');
+
+  async function clickTodoEditButton() {
+    await userEvent.click(TodoEditButton());
+  }
+  async function clearTodoEditInput() {
+    await userEvent.clear(TodoEditInput());
+  }
+  async function changeTodoEditInput(text: string) {
+    await userEvent.type(TodoEditInput(), text);
+  }
+  async function clickTodoEditSaveButton() {
+    await userEvent.click(TodoEditSaveButton());
+  }
+  async function clickTodoDeleteButton() {
+    await userEvent.click(TodoDeleteButton());
+  }
+  async function clickTodo() {
+    await userEvent.click(TodoText());
+  }
+
+  return {
+    completeIcon,
+    incompleteIcon,
+    todoData,
+    onDelete,
+    onToggle,
+    onUpdate,
+    result,
+    Todo,
+    TodoIcon,
+    TodoText,
+    TodoEditButton,
+    TodoDeleteButton,
+    TodoEdit,
+    TodoEditInput,
+    TodoEditSaveButton,
+    clickTodoEditButton,
+    clearTodoEditInput,
+    changeTodoEditInput,
+    clickTodoEditSaveButton,
+    clickTodoDeleteButton,
+    clickTodo,
+  }
+}
+
+describe('<TodoHeader />', () => {
+  test('초기 렌더링 시 화면에 올바르게 노출된다.', () => {
+    const { Todo, TodoIcon, TodoText, incompleteIcon, todoData } = renderTodoItem();
+
+    expect(Todo()).toBeInTheDocument();
+    expect(TodoIcon().className).toBe(incompleteIcon);
+    expect(TodoText()).toHaveTextContent(todoData.task);
+  });
+
+  test('Edit 버튼을 클릭 시 수정 가능한 Edit Todo이 노출된다.', async () => {
+    const {clickTodoEditButton, TodoEdit, TodoEditInput, TodoEditSaveButton, todoData,} = renderTodoItem();
+    await clickTodoEditButton();
+
+    expect(TodoEdit()).toBeInTheDocument();
+    expect(TodoEditInput()).toHaveValue(todoData.task);
+    expect(TodoEditSaveButton()).toBeInTheDocument();
+  });
+
+  test('Edit Input의 값을 수정하고 Save 버튼을 클릭 시 이벤트가 호출된다.', async () => {
+    const {
+      clickTodoEditButton,
+      Todo,
+      TodoEdit,
+      TodoEditInput,
+      TodoEditSaveButton,
+      todoData,
+      clearTodoEditInput,
+      changeTodoEditInput,
+      clickTodoEditSaveButton,
+      onUpdate
+    } = renderTodoItem();
+    const newText = 'Study React';
+
+    await clickTodoEditButton();
+
+    expect(TodoEdit()).toBeInTheDocument();
+    expect(TodoEditInput()).toHaveValue(todoData.task);
+    expect(TodoEditSaveButton()).toBeInTheDocument();
+
+    await clearTodoEditInput();
+    await changeTodoEditInput(newText);
+    await clickTodoEditSaveButton();
+
+    expect(onUpdate).toHaveBeenCalledWith(todoData.idx, newText);
+    expect(Todo()).toBeInTheDocument();
+  });
+
+  test('Delete 버튼 클릭 시 삭제 이벤트가 호출된다.', async () => {
+    const { clickTodoDeleteButton, onDelete, todoData } = renderTodoItem();
+
+    await clickTodoDeleteButton();
+
+    expect(onDelete).toHaveBeenCalledWith(todoData.idx);
+  });
+
+
+  test('Todo 클릭 시 상태 변경 이벤트가 호출된다.', async () => {
+    const { clickTodo, onToggle, todoData } = renderTodoItem();
+
+    await clickTodo();
+
+    expect(onToggle).toHaveBeenCalledWith(todoData.idx);
+  });
+});

--- a/leo/components/TodoItem/index.leo.test.tsx
+++ b/leo/components/TodoItem/index.leo.test.tsx
@@ -69,7 +69,7 @@ export function renderTodoItem() {
   }
 }
 
-describe('<TodoHeader />', () => {
+describe('<TodoItem />', () => {
   test('초기 렌더링 시 화면에 올바르게 노출된다.', () => {
     const { Todo, TodoIcon, TodoText, incompleteIcon, todoData } = renderTodoItem();
 
@@ -78,8 +78,9 @@ describe('<TodoHeader />', () => {
     expect(TodoText()).toHaveTextContent(todoData.task);
   });
 
-  test('Edit 버튼을 클릭 시 수정 가능한 Edit Todo이 노출된다.', async () => {
-    const {clickTodoEditButton, TodoEdit, TodoEditInput, TodoEditSaveButton, todoData,} = renderTodoItem();
+  test('Edit 버튼을 클릭하면 Edit Todo가 노출된다.', async () => {
+    const {clickTodoEditButton, TodoEdit, TodoEditInput, TodoEditSaveButton, todoData } = renderTodoItem();
+
     await clickTodoEditButton();
 
     expect(TodoEdit()).toBeInTheDocument();
@@ -87,13 +88,10 @@ describe('<TodoHeader />', () => {
     expect(TodoEditSaveButton()).toBeInTheDocument();
   });
 
-  test('Edit Input의 값을 수정하고 Save 버튼을 클릭 시 이벤트가 호출된다.', async () => {
+  test('Edit Input의 값을 수정하고 Save 버튼을 클릭 시 Update 이벤트가 호출된다.', async () => {
     const {
       clickTodoEditButton,
       Todo,
-      TodoEdit,
-      TodoEditInput,
-      TodoEditSaveButton,
       todoData,
       clearTodoEditInput,
       changeTodoEditInput,
@@ -103,11 +101,6 @@ describe('<TodoHeader />', () => {
     const newText = 'Study React';
 
     await clickTodoEditButton();
-
-    expect(TodoEdit()).toBeInTheDocument();
-    expect(TodoEditInput()).toHaveValue(todoData.task);
-    expect(TodoEditSaveButton()).toBeInTheDocument();
-
     await clearTodoEditInput();
     await changeTodoEditInput(newText);
     await clickTodoEditSaveButton();
@@ -116,7 +109,7 @@ describe('<TodoHeader />', () => {
     expect(Todo()).toBeInTheDocument();
   });
 
-  test('Delete 버튼 클릭 시 삭제 이벤트가 호출된다.', async () => {
+  test('Delete 버튼 클릭 시 Delete 이벤트가 호출된다.', async () => {
     const { clickTodoDeleteButton, onDelete, todoData } = renderTodoItem();
 
     await clickTodoDeleteButton();
@@ -125,7 +118,7 @@ describe('<TodoHeader />', () => {
   });
 
 
-  test('Todo 클릭 시 상태 변경 이벤트가 호출된다.', async () => {
+  test('Todo 클릭 시 상태 Toggle 이벤트가 호출된다.', async () => {
     const { clickTodo, onToggle, todoData } = renderTodoItem();
 
     await clickTodo();

--- a/leo/components/TodoItem/index.tsx
+++ b/leo/components/TodoItem/index.tsx
@@ -26,18 +26,18 @@ const TodoItem = ({ data: { idx, task, completed }, toggleTodo, updateTodo, dele
   return isEdit ? (
     <S.EditTodo data-testid='todoEdit' isCompleted={completed}>
       <form onSubmit={handleUpdate}>
-        <input type='text' value={updateTask} onChange={handleUpdateTask} />
-        <button>save</button>
+        <input data-testid='todoEditInput' type='text' value={updateTask} onChange={handleUpdateTask} />
+        <button data-testid='todoEditSaveButton'>save</button>
       </form>
     </S.EditTodo>
   ) : (
     <S.ViewTodo data-testid='todo' isCompleted={completed}>
-      <i className={completed ? 'xi-check-square' : 'xi-checkbox-blank'} />
-      <p onClick={handleToggle}>{task}</p>
-      <button type='button' onClick={handleEditStatus}>
+      <i data-testid='todoIcon' className={completed ? 'xi-check-square' : 'xi-checkbox-blank'} />
+      <p data-testid='todoText' onClick={handleToggle}>{task}</p>
+      <button data-testid='todoEditButton' type='button' onClick={handleEditStatus}>
         <i className='xi-pen' />
       </button>
-      <button type='button' onClick={handleRemove}>
+      <button data-testid='todoDeleteButton' type='button' onClick={handleRemove}>
         <i className='xi-trash' />
       </button>
     </S.ViewTodo>

--- a/leo/components/TodoItem/index.tsx
+++ b/leo/components/TodoItem/index.tsx
@@ -24,14 +24,14 @@ const TodoItem = ({ data: { idx, task, completed }, toggleTodo, updateTodo, dele
   };
 
   return isEdit ? (
-    <S.EditTodo isCompleted={completed}>
+    <S.EditTodo data-testid='todoEdit' isCompleted={completed}>
       <form onSubmit={handleUpdate}>
         <input type='text' value={updateTask} onChange={handleUpdateTask} />
         <button>save</button>
       </form>
     </S.EditTodo>
   ) : (
-    <S.ViewTodo isCompleted={completed}>
+    <S.ViewTodo data-testid='todo' isCompleted={completed}>
       <i className={completed ? 'xi-check-square' : 'xi-checkbox-blank'} />
       <p onClick={handleToggle}>{task}</p>
       <button type='button' onClick={handleEditStatus}>

--- a/leo/package.json
+++ b/leo/package.json
@@ -23,7 +23,11 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^8.19.0",
     "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@testing-library/user-event": "^14.4.3",
     "@types/node": "18.11.0",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
@@ -31,7 +35,7 @@
     "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
-    "babel-jest": "^29.2.1",
+    "babel-jest": "^29.2.2",
     "babel-plugin-styled-components": "^2.0.7",
     "eslint": "^8.25.0",
     "eslint-config-next": "12.3.1",
@@ -40,9 +44,9 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.31.10",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "jest": "^29.2.1",
+    "jest": "^29.2.2",
     "jest-dom": "^4.0.0",
-    "jest-environment-jsdom": "^29.2.1",
+    "jest-environment-jsdom": "^29.2.2",
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "typescript": "4.8.4"

--- a/leo/pages/index.leo.test.tsx
+++ b/leo/pages/index.leo.test.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event'
+import TodoList from './index';
+
+function renderTodoList() {
+  const ENTER_KEY = '[Enter]';
+  const TEXT_ARRAY = ['Send Email', 'Bake Cake', 'Checked TodoList'];
+
+  const result = render(<TodoList />);
+
+  const Title = () => result.getByTestId('title');
+  const Count = () => result.getByTestId('count');
+  const AddInput = () => result.getByTestId('addInput');
+  const AddButton = () => result.getByTestId('addButton');
+  const Todos = () => result.queryAllByTestId('todo');
+  const EditTodos = () => result.queryAllByTestId('todoEdit');
+
+  const Todo = (todoIndex: number) => Todos()[todoIndex].children[1];
+  const EditTodo = (todoIndex: number) => EditTodos()[todoIndex];
+  const TodoDeleteButton = (todoIndex: number) => Todos()[todoIndex].children[3];
+  const TodoEditButton = (todoIndex: number) => Todos()[todoIndex].children[2];
+  const TodoIcon = (todoIndex: number) => Todos()[todoIndex].children[0];
+  const TodoEditInput = (todoIndex: number) => EditTodos()[todoIndex].children[0].children[0];
+  const TodoEditSaveButton = (todoIndex: number) => EditTodos()[todoIndex].children[0].children[1];
+
+  async function changeAddInput(text: string) {
+    await userEvent.type(AddInput(), text);
+  }
+  async function clickAddButton() {
+    await userEvent.click(AddButton());
+  }
+  async function addTodos(array: string[]) {
+    for (const value of array) {
+      await changeAddInput(value);
+
+      if (value === array[0]) await changeAddInput(ENTER_KEY);
+      else await clickAddButton();
+    }
+  }
+  async function clickTodo(todoIndex: number) {
+    await userEvent.click(Todo(todoIndex));
+  }
+  async function clickTodoDeleteButton(todoIndex: number) {
+    await userEvent.click(TodoDeleteButton(todoIndex));
+  }
+  async function clickTodoEditButton(todoIndex: number) {
+    await userEvent.click(TodoEditButton(todoIndex));
+  }
+  async function clearTodoEditInput(todoIndex: number) {
+    await userEvent.clear(TodoEditInput(todoIndex));
+  }
+  async function changeTodoEditInput(todoIndex: number, text: string) {
+    await userEvent.type(TodoEditInput(todoIndex), text);
+  }
+  async function clickTodoEditSaveButton(todoIndex: number) {
+    await userEvent.click(TodoEditSaveButton(todoIndex));
+  }
+
+  const getCountText = (total: number, completed: number) => `총 ${total}개 중 ${completed}개 완료`;
+  const getTodoText = (todoIndex: number) => [...TEXT_ARRAY].reverse()[todoIndex];
+
+  return {
+    TEXT_ARRAY,
+    result,
+    Title,
+    Count,
+    AddInput,
+    AddButton,
+    Todos,
+    EditTodos,
+    Todo,
+    EditTodo,
+    TodoDeleteButton,
+    TodoEditInput,
+    TodoIcon,
+    getCountText,
+    getTodoText,
+    addTodos,
+    clickTodo,
+    clickTodoDeleteButton,
+    clickTodoEditButton,
+    clearTodoEditInput,
+    changeTodoEditInput,
+    clickTodoEditSaveButton,
+  }
+}
+
+describe('<TodoList />', () => {
+  test('Render TodoList', () => {
+    const { Title, Count, AddInput, AddButton, Todos, getCountText } = renderTodoList();
+
+    expect(Title()).toBeInTheDocument();
+    expect(Count()).toHaveTextContent(getCountText(0,0));
+    expect(AddInput()).toHaveValue('');
+    expect(AddButton()).toBeInTheDocument();
+    expect(Todos().length).toBe(0);
+  });
+
+  test('Add Todo', async () => {
+    const { TEXT_ARRAY, addTodos, Count, AddInput, Todos, Todo, getCountText, getTodoText } = renderTodoList();
+    const newTodoIndex = 0;
+
+    await addTodos(TEXT_ARRAY);
+
+    expect(Count()).toHaveTextContent(getCountText(TEXT_ARRAY.length, 0));
+    expect(AddInput()).toHaveValue('');
+    expect(Todos().length).toBe(TEXT_ARRAY.length);
+    expect(Todo(newTodoIndex)).toHaveTextContent(getTodoText(newTodoIndex));
+  });
+
+  test('Delete Todo', async () => {
+    const { TEXT_ARRAY, addTodos, clickTodoDeleteButton, Count, Todos, getCountText, getTodoText } = renderTodoList();
+    const targetTodoIndex = 0;
+    const remainTodoLength = TEXT_ARRAY.length - 1;
+
+    await addTodos(TEXT_ARRAY);
+    await clickTodoDeleteButton(targetTodoIndex);
+
+    expect(Count()).toHaveTextContent(getCountText(remainTodoLength, 0));
+    expect(Todos().length).toBe(remainTodoLength);
+    for (const todo of Todos()) {
+      expect(todo).not.toHaveTextContent(getTodoText(targetTodoIndex));
+    }
+  });
+
+  test('Edit Todo', async () => {
+    const { TEXT_ARRAY, addTodos, clickTodoEditButton, EditTodo, changeTodoEditInput, clickTodoEditSaveButton, getTodoText, Todo, TodoEditInput, clearTodoEditInput } = renderTodoList();
+    const targetTodoIndex = 0;
+    const changeText = 'Learn jest';
+
+    await addTodos(TEXT_ARRAY);
+    await clickTodoEditButton(targetTodoIndex);
+
+    expect(EditTodo(targetTodoIndex)).toBeInTheDocument();
+    expect(TodoEditInput(targetTodoIndex)).toHaveValue(getTodoText(targetTodoIndex));
+
+    await clearTodoEditInput(targetTodoIndex);
+    await changeTodoEditInput(targetTodoIndex, changeText);
+    await clickTodoEditSaveButton(targetTodoIndex);
+
+    expect(EditTodo(targetTodoIndex)).toBeUndefined();
+    expect(Todo(targetTodoIndex)).toHaveTextContent(changeText);
+  });
+
+  test('Change Todo state', async () => {
+    const { TEXT_ARRAY, addTodos, clickTodo, getCountText, Count, TodoIcon } = renderTodoList();
+    const targetTodoIndex = 0;
+    const completeIcon = 'xi-check-square';
+    const incompleteIcon = 'xi-checkbox-blank';
+
+    await addTodos(TEXT_ARRAY);
+    await clickTodo(targetTodoIndex);
+
+    expect(Count()).toHaveTextContent(getCountText(TEXT_ARRAY.length, 1));
+    expect(TodoIcon(targetTodoIndex).className).toBe(completeIcon);
+
+
+    await clickTodo(targetTodoIndex);
+
+    expect(Count()).toHaveTextContent(getCountText(TEXT_ARRAY.length, 0));
+    expect(TodoIcon(targetTodoIndex).className).toBe(incompleteIcon);
+  });
+});

--- a/leo/pages/index.leo.test.tsx
+++ b/leo/pages/index.leo.test.tsx
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event'
 import TodoList from './index';
 
-function renderTodoList() {
+export function renderTodoList() {
   const ENTER_KEY = '[Enter]';
   const TEXT_ARRAY = ['Send Email', 'Bake Cake', 'Checked TodoList'];
 
@@ -87,7 +87,7 @@ function renderTodoList() {
   }
 }
 
-describe('<TodoList />', () => {
+describe('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출된다.', () => {
   test('Render TodoList', () => {
     const { Title, Count, AddInput, AddButton, Todos, getCountText } = renderTodoList();
 
@@ -98,7 +98,7 @@ describe('<TodoList />', () => {
     expect(Todos().length).toBe(0);
   });
 
-  test('Add Todo', async () => {
+  test('Add Input을 통해 새로운 Todo를 추가했을 때 TodoList가 갱신된다.', async () => {
     const { TEXT_ARRAY, addTodos, Count, AddInput, Todos, Todo, getCountText, getTodoText } = renderTodoList();
     const newTodoIndex = 0;
 
@@ -110,7 +110,7 @@ describe('<TodoList />', () => {
     expect(Todo(newTodoIndex)).toHaveTextContent(getTodoText(newTodoIndex));
   });
 
-  test('Delete Todo', async () => {
+  test('Todo의 삭제 버튼을 클릭했을 때 해당 Todo가 TodoList에서 제거된다.', async () => {
     const { TEXT_ARRAY, addTodos, clickTodoDeleteButton, Count, Todos, getCountText, getTodoText } = renderTodoList();
     const targetTodoIndex = 0;
     const remainTodoLength = TEXT_ARRAY.length - 1;
@@ -125,7 +125,7 @@ describe('<TodoList />', () => {
     }
   });
 
-  test('Edit Todo', async () => {
+  test('Todo의 Edit 버튼을 클릭했을 때 해당 Todo를 수정할 수 있는 Input이 노출되고 텍스트를 수정할 수 있다.', async () => {
     const { TEXT_ARRAY, addTodos, clickTodoEditButton, EditTodo, changeTodoEditInput, clickTodoEditSaveButton, getTodoText, Todo, TodoEditInput, clearTodoEditInput } = renderTodoList();
     const targetTodoIndex = 0;
     const changeText = 'Learn jest';
@@ -144,7 +144,7 @@ describe('<TodoList />', () => {
     expect(Todo(targetTodoIndex)).toHaveTextContent(changeText);
   });
 
-  test('Change Todo state', async () => {
+  test('Todo를 클릭했을 때 해당 Todo의 completed 상태 값이 변경된다.', async () => {
     const { TEXT_ARRAY, addTodos, clickTodo, getCountText, Count, TodoIcon } = renderTodoList();
     const targetTodoIndex = 0;
     const completeIcon = 'xi-check-square';

--- a/leo/pages/index.leo.test.tsx
+++ b/leo/pages/index.leo.test.tsx
@@ -96,7 +96,7 @@ describe('<TodoList />', () => {
   });
 
   test('Add Input을 통해 새로운 Todo를 추가했을 때 TodoList가 갱신된다.', async () => {
-    const { TEXT_ARRAY, addTodos, Count, AddInput, Todos, Todo, getCountText, getTodoText } = renderTodoList();
+    const { TEXT_ARRAY, addTodos, Count, Todos, Todo, getCountText, getTodoText } = renderTodoList();
     const newTodoIndex = 0;
 
     await addTodos(TEXT_ARRAY);

--- a/leo/pages/index.leo.test.tsx
+++ b/leo/pages/index.leo.test.tsx
@@ -87,14 +87,11 @@ export function renderTodoList() {
   }
 }
 
-describe('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출된다.', () => {
-  test('Render TodoList', () => {
-    const { Title, Count, AddInput, AddButton, Todos, getCountText } = renderTodoList();
+describe('<TodoList />', () => {
+  test('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출된다.', () => {
+    const { Count, Todos, getCountText } = renderTodoList();
 
-    expect(Title()).toBeInTheDocument();
     expect(Count()).toHaveTextContent(getCountText(0,0));
-    expect(AddInput()).toHaveValue('');
-    expect(AddButton()).toBeInTheDocument();
     expect(Todos().length).toBe(0);
   });
 
@@ -105,7 +102,6 @@ describe('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출�
     await addTodos(TEXT_ARRAY);
 
     expect(Count()).toHaveTextContent(getCountText(TEXT_ARRAY.length, 0));
-    expect(AddInput()).toHaveValue('');
     expect(Todos().length).toBe(TEXT_ARRAY.length);
     expect(Todo(newTodoIndex)).toHaveTextContent(getTodoText(newTodoIndex));
   });
@@ -144,7 +140,7 @@ describe('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출�
     expect(Todo(targetTodoIndex)).toHaveTextContent(changeText);
   });
 
-  test('Todo를 클릭했을 때 해당 Todo의 completed 상태 값이 변경된다.', async () => {
+  test('Todo를 클릭 시 해당 Todo의 completed 상태 값이 변경된다.', async () => {
     const { TEXT_ARRAY, addTodos, clickTodo, getCountText, Count, TodoIcon } = renderTodoList();
     const targetTodoIndex = 0;
     const completeIcon = 'xi-check-square';
@@ -155,7 +151,6 @@ describe('TodoList를 처음 렌더링했을 때 화면이 올바르게 노출�
 
     expect(Count()).toHaveTextContent(getCountText(TEXT_ARRAY.length, 1));
     expect(TodoIcon(targetTodoIndex).className).toBe(completeIcon);
-
 
     await clickTodo(targetTodoIndex);
 

--- a/leo/pages/index.tsx
+++ b/leo/pages/index.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import type { NextPage } from 'next';
 import styled from 'styled-components';
 import TodoHeader from '../components/TodoHeader';
-import TodoItem from '../components/TodoItem';
 import TodoAddForm from '../components/TodoAddForm';
+import TodoItem from '../components/TodoItem';
 
 const TodoContainer = styled.div`
   max-width: 500px;
@@ -17,7 +17,7 @@ const TodoContainer = styled.div`
   & > ul {
     padding-left: 25px;
     padding-right: 25px;
-  }
+  } 
 
   & > ul {
     padding-bottom: 25px;
@@ -26,10 +26,10 @@ const TodoContainer = styled.div`
 
 export type ITodo = { idx: string; task: string; completed: boolean };
 
-const Home: NextPage = () => {
+const TodoList: NextPage = () => {
   const [todos, setTodos] = useState<ITodo[]>([]);
 
-  const addTodo = (todo: ITodo) => setTodos([...todos, todo]);
+  const addTodo = (todo: ITodo) => setTodos([todo, ...todos]);
 
   const deleteTodo = (idx: string) => setTodos(todos.filter((item) => item.idx !== idx));
 
@@ -74,4 +74,4 @@ const Home: NextPage = () => {
   );
 };
 
-export default Home;
+export default TodoList;

--- a/leo/yarn.lock
+++ b/leo/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
   integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
@@ -278,7 +278,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.18.9", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.9", "@babel/runtime@^7.9.2":
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
   integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
@@ -408,15 +408,15 @@
     jest-util "^29.2.1"
     slash "^3.0.0"
 
-"@jest/core@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.2.1.tgz#30af794ebd73bfb87cd8ba36718738dfe38b772e"
-  integrity sha512-kuLKYqnqgerXkBUwlHVxeSuhSnd+JMnMCLfU98bpacBSfWEJPegytDh3P2m15/JHzet32hGGld4KR4OzMb6/Tg==
+"@jest/core@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.2.2.tgz#207aa8973d9de8769f9518732bc5f781efc3ffa7"
+  integrity sha512-susVl8o2KYLcZhhkvSB+b7xX575CX3TmSvxfeDjpRko7KmT89rHkXj6XkDkNpSeFMBzIENw5qIchO9HC9Sem+A==
   dependencies:
     "@jest/console" "^29.2.1"
-    "@jest/reporters" "^29.2.1"
+    "@jest/reporters" "^29.2.2"
     "@jest/test-result" "^29.2.1"
-    "@jest/transform" "^29.2.1"
+    "@jest/transform" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
@@ -425,32 +425,32 @@
     exit "^0.1.2"
     graceful-fs "^4.2.9"
     jest-changed-files "^29.2.0"
-    jest-config "^29.2.1"
+    jest-config "^29.2.2"
     jest-haste-map "^29.2.1"
     jest-message-util "^29.2.1"
     jest-regex-util "^29.2.0"
-    jest-resolve "^29.2.1"
-    jest-resolve-dependencies "^29.2.1"
-    jest-runner "^29.2.1"
-    jest-runtime "^29.2.1"
-    jest-snapshot "^29.2.1"
+    jest-resolve "^29.2.2"
+    jest-resolve-dependencies "^29.2.2"
+    jest-runner "^29.2.2"
+    jest-runtime "^29.2.2"
+    jest-snapshot "^29.2.2"
     jest-util "^29.2.1"
-    jest-validate "^29.2.1"
-    jest-watcher "^29.2.1"
+    jest-validate "^29.2.2"
+    jest-watcher "^29.2.2"
     micromatch "^4.0.4"
     pretty-format "^29.2.1"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.2.1.tgz#acb1994fbd5ad02819a1a34a923c531e6923b665"
-  integrity sha512-EutqA7T/X6zFjw6mAWRHND+ZkTPklmIEWCNbmwX6uCmOrFrWaLbDZjA+gePHJx6fFMMRvNfjXcvzXEtz54KPlg==
+"@jest/environment@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.2.2.tgz#481e729048d42e87d04842c38aa4d09c507f53b0"
+  integrity sha512-OWn+Vhu0I1yxuGBJEFFekMYc8aGBGrY4rt47SOh/IFaI+D7ZHCk7pKRiSoZ2/Ml7b0Ony3ydmEHRx/tEOC7H1A==
   dependencies:
-    "@jest/fake-timers" "^29.2.1"
+    "@jest/fake-timers" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
 
 "@jest/expect-utils@^29.2.1":
   version "29.2.1"
@@ -459,45 +459,52 @@
   dependencies:
     jest-get-type "^29.2.0"
 
-"@jest/expect@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.2.1.tgz#8d99be3886ebfcffd6cabb2b46602a301b976ffe"
-  integrity sha512-o14R2t2tHHHudwji43UKkzmmH49xfF5T++FQBK2tl88qwuBWQOcx7fNUYl+mA/9TPNAN0FkQ3usnpyS8FUwsvQ==
+"@jest/expect-utils@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/expect-utils/-/expect-utils-29.2.2.tgz#460a5b5a3caf84d4feb2668677393dd66ff98665"
+  integrity sha512-vwnVmrVhTmGgQzyvcpze08br91OL61t9O0lJMDyb6Y/D8EKQ9V7rGUb/p7PDt0GPzK0zFYqXWFo4EO2legXmkg==
   dependencies:
-    expect "^29.2.1"
-    jest-snapshot "^29.2.1"
+    jest-get-type "^29.2.0"
 
-"@jest/fake-timers@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.2.1.tgz#786d60e8cb60ca70c9f913cb49fcc77610c072bb"
-  integrity sha512-KWil+8fef7Uj/P/PTZlPKk1Pw117wAmr71VWFV8ZDtRtkwmTG8oY4IRf0Ss44J2y5CYRy8d/zLOhxyoGRENjvA==
+"@jest/expect@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/expect/-/expect-29.2.2.tgz#81edbd33afbde7795ca07ff6b4753d15205032e4"
+  integrity sha512-zwblIZnrIVt8z/SiEeJ7Q9wKKuB+/GS4yZe9zw7gMqfGf4C5hBLGrVyxu1SzDbVSqyMSlprKl3WL1r80cBNkgg==
+  dependencies:
+    expect "^29.2.2"
+    jest-snapshot "^29.2.2"
+
+"@jest/fake-timers@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-29.2.2.tgz#d8332e6e3cfa99cde4bc87d04a17d6b699deb340"
+  integrity sha512-nqaW3y2aSyZDl7zQ7t1XogsxeavNpH6kkdq+EpXncIDvAkjvFD7hmhcIs1nWloengEWUoWqkqSA6MSbf9w6DgA==
   dependencies:
     "@jest/types" "^29.2.1"
     "@sinonjs/fake-timers" "^9.1.2"
     "@types/node" "*"
     jest-message-util "^29.2.1"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
     jest-util "^29.2.1"
 
-"@jest/globals@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.2.1.tgz#6933beb8b4e43b990409a19c462fde7b71210e63"
-  integrity sha512-Z4EejYPP1OPVq2abk1+9urAwJqkgw5jB2UJGlPjb5ZwzPQF8WLMcigKEfFzZb2OHhEVPP0RZD0/DbVTY1R6iQA==
+"@jest/globals@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-29.2.2.tgz#205ff1e795aa774301c2c0ba0be182558471b845"
+  integrity sha512-/nt+5YMh65kYcfBhj38B3Hm0Trk4IsuMXNDGKE/swp36yydBWfz3OXkLqkSvoAtPW8IJMSJDFCbTM2oj5SNprw==
   dependencies:
-    "@jest/environment" "^29.2.1"
-    "@jest/expect" "^29.2.1"
+    "@jest/environment" "^29.2.2"
+    "@jest/expect" "^29.2.2"
     "@jest/types" "^29.2.1"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
 
-"@jest/reporters@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.2.1.tgz#599e4376823751fdda50f2ca97243e013da10c4d"
-  integrity sha512-sCsfUKM/yIF4nNed3e/rIgVIS58EiASGMDEPWqItfLZ9UO1ALW2ASDNJzdWkxEt0T8o2Ztj619G0KKrvK+McAw==
+"@jest/reporters@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-29.2.2.tgz#69b395f79c3a97ce969ce05ccf1a482e5d6de290"
+  integrity sha512-AzjL2rl2zJC0njIzcooBvjA4sJjvdoq98sDuuNs4aNugtLPSQ+91nysGKRF0uY1to5k0MdGMdOBggUsPqvBcpA==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
     "@jest/console" "^29.2.1"
     "@jest/test-result" "^29.2.1"
-    "@jest/transform" "^29.2.1"
+    "@jest/transform" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@jridgewell/trace-mapping" "^0.3.15"
     "@types/node" "*"
@@ -545,20 +552,20 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.2.1.tgz#cafd2c5f3528c70bd4cc243800459ac366e480cc"
-  integrity sha512-O/pnk0/xGj3lxPVNwB6HREJ7AYvUdyP2xo/s14/9Dtf091HoOeyIhWLKQE/4HzB8lNQBMo6J5mg0bHz/uCWK7w==
+"@jest/test-sequencer@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-29.2.2.tgz#4ac7487b237e517a1f55e7866fb5553f6e0168b9"
+  integrity sha512-Cuc1znc1pl4v9REgmmLf0jBd3Y65UXJpioGYtMr/JNpQEIGEzkmHhy6W6DLbSsXeUA13TDzymPv0ZGZ9jH3eIw==
   dependencies:
     "@jest/test-result" "^29.2.1"
     graceful-fs "^4.2.9"
     jest-haste-map "^29.2.1"
     slash "^3.0.0"
 
-"@jest/transform@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.2.1.tgz#f3d8154edd19cdbcaf1d6646bd8f4ff7812318a2"
-  integrity sha512-xup+iEuaIRSQabQaeqxaQyN0vg1Dctrp9oTObQsNf3sZEowTIa5cANYuoyi8Tqhg4GCqEVLTf18KW7ii0UeFVA==
+"@jest/transform@^29.2.2":
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.2.2.tgz#dfc03fc092b31ffea0c55917728e75bfcf8b5de6"
+  integrity sha512-aPe6rrletyuEIt2axxgdtxljmzH8O/nrov4byy6pDw9S8inIrTV+2PnjyP/oFHMSynzGxJ2s6OHowBNMXp/Jzg==
   dependencies:
     "@babel/core" "^7.11.6"
     "@jest/types" "^29.2.1"
@@ -757,6 +764,20 @@
   dependencies:
     tslib "^2.4.0"
 
+"@testing-library/dom@^8.19.0", "@testing-library/dom@^8.5.0":
+  version "8.19.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.19.0.tgz#bd3f83c217ebac16694329e413d9ad5fdcfd785f"
+  integrity sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^5.16.5":
   version "5.16.5"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.16.5.tgz#3912846af19a29b2dbf32a6ae9c31ef52580074e"
@@ -772,10 +793,37 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
+"@testing-library/react@^13.4.0":
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.4.0.tgz#6a31e3bf5951615593ad984e96b9e5e2d9380966"
+  integrity sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
+
+"@testing-library/user-event@^14.4.3":
+  version "14.4.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.4.3.tgz#af975e367743fa91989cd666666aec31a8f50591"
+  integrity sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==
+
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.1.14":
   version "7.1.19"
@@ -895,6 +943,13 @@
   version "18.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
   integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-dom@^18.0.0":
+  version "18.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.7.tgz#ee7cf8ec4e6977e3f0a7b1d38bd89c75aa2aec28"
+  integrity sha512-HaXc+BbqAZE1RdsK3tC8SbkFy6UL2xF76lT9rQs5JkPrJg3rWA3Ou/Lhw3YJQzEDkBpmJ79nBsfnd05WrBd2QQ==
   dependencies:
     "@types/react" "*"
 
@@ -1207,12 +1262,12 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-jest@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.2.1.tgz#213c47e28072de11bdb98c9d29b89f2ab99664f1"
-  integrity sha512-gQJwArok0mqoREiCYhXKWOgUhElJj9DpnssW6GL8dG7ARYqHEhrM9fmPHTjdqEGRVXZAd6+imo3/Vwa8TjLcsw==
+babel-jest@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.2.2.tgz#2c15abd8c2081293c9c3f4f80a4ed1d51542fee5"
+  integrity sha512-kkq2QSDIuvpgfoac3WZ1OOcHsQQDU5xYk2Ql7tLdJ8BVAYbefEXal+NfS45Y5LVZA7cxC8KYcQMObpCt1J025w==
   dependencies:
-    "@jest/transform" "^29.2.1"
+    "@jest/transform" "^29.2.2"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
     babel-preset-jest "^29.2.0"
@@ -1382,7 +1437,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1619,7 +1674,7 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.6:
+dom-accessibility-api@^0.5.6, dom-accessibility-api@^0.5.9:
   version "0.5.14"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz#56082f71b1dc7aac69d83c4285eef39c15d93f56"
   integrity sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==
@@ -1636,10 +1691,10 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-emittery@^0.10.2:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.10.2.tgz#902eec8aedb8c41938c46e9385e9db7e03182933"
-  integrity sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==
+emittery@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
+  integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1997,7 +2052,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.0.0, expect@^29.2.1:
+expect@^29.0.0:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.2.1.tgz#25752d0df92d3daa5188dc8804de1f30759658cf"
   integrity sha512-BJtA754Fba0YWRWHgjKUMTA3ltWarKgITXHQnbZ2mTxTXC4yMQlR0FI7HkB3fJYkhWBf4qjNiqvg3LDtXCcVRQ==
@@ -2005,6 +2060,17 @@ expect@^29.0.0, expect@^29.2.1:
     "@jest/expect-utils" "^29.2.1"
     jest-get-type "^29.2.0"
     jest-matcher-utils "^29.2.1"
+    jest-message-util "^29.2.1"
+    jest-util "^29.2.1"
+
+expect@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-29.2.2.tgz#ba2dd0d7e818727710324a6e7f13dd0e6d086106"
+  integrity sha512-hE09QerxZ5wXiOhqkXy5d2G9ar+EqOyifnCXCpMNu+vZ6DG9TJ6CO2c2kPDSLqERTTWrO7OZj8EkYHQqSd78Yw==
+  dependencies:
+    "@jest/expect-utils" "^29.2.2"
+    jest-get-type "^29.2.0"
+    jest-matcher-utils "^29.2.2"
     jest-message-util "^29.2.1"
     jest-util "^29.2.1"
 
@@ -2565,13 +2631,13 @@ jest-changed-files@^29.2.0:
     execa "^5.0.0"
     p-limit "^3.1.0"
 
-jest-circus@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.2.1.tgz#1385353d9bca6acf58f916068bbeffcfc95bef02"
-  integrity sha512-W+ZQQ5ln4Db2UZNM4NJIeasnhCdDhSuYW4eLgNAUi0XiSSpF634Kc5wiPvGiHvTgXMFVn1ZgWIijqhi9+kLNLg==
+jest-circus@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-29.2.2.tgz#1dc4d35fd49bf5e64d3cc505fb2db396237a6dfa"
+  integrity sha512-upSdWxx+Mh4DV7oueuZndJ1NVdgtTsqM4YgywHEx05UMH5nxxA2Qu9T9T9XVuR021XxqSoaKvSmmpAbjwwwxMw==
   dependencies:
-    "@jest/environment" "^29.2.1"
-    "@jest/expect" "^29.2.1"
+    "@jest/environment" "^29.2.2"
+    "@jest/expect" "^29.2.2"
     "@jest/test-result" "^29.2.1"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
@@ -2580,56 +2646,56 @@ jest-circus@^29.2.1:
     dedent "^0.7.0"
     is-generator-fn "^2.0.0"
     jest-each "^29.2.1"
-    jest-matcher-utils "^29.2.1"
+    jest-matcher-utils "^29.2.2"
     jest-message-util "^29.2.1"
-    jest-runtime "^29.2.1"
-    jest-snapshot "^29.2.1"
+    jest-runtime "^29.2.2"
+    jest-snapshot "^29.2.2"
     jest-util "^29.2.1"
     p-limit "^3.1.0"
     pretty-format "^29.2.1"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-cli@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.2.1.tgz#fbfa90b87b27a04e1041cc9d33ee80f32e2f2528"
-  integrity sha512-UIMD5aNqvPKpdlJSaeUAoLfxsh9TZvOkaMETx5qXnkboc317bcbb0eLHbIj8sFBHdcJAIAM+IRKnIU7Wi61MBw==
+jest-cli@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.2.2.tgz#feaf0aa57d327e80d4f2f18d5f8cd2e77cac5371"
+  integrity sha512-R45ygnnb2CQOfd8rTPFR+/fls0d+1zXS6JPYTBBrnLPrhr58SSuPTiA5Tplv8/PXpz4zXR/AYNxmwIj6J6nrvg==
   dependencies:
-    "@jest/core" "^29.2.1"
+    "@jest/core" "^29.2.2"
     "@jest/test-result" "^29.2.1"
     "@jest/types" "^29.2.1"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.9"
     import-local "^3.0.2"
-    jest-config "^29.2.1"
+    jest-config "^29.2.2"
     jest-util "^29.2.1"
-    jest-validate "^29.2.1"
+    jest-validate "^29.2.2"
     prompts "^2.0.1"
     yargs "^17.3.1"
 
-jest-config@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.2.1.tgz#2182af014d6c73978208626335db5134803dd183"
-  integrity sha512-EV5F1tQYW/quZV2br2o88hnYEeRzG53Dfi6rSG3TZBuzGQ6luhQBux/RLlU5QrJjCdq3LXxRRM8F1LP6DN1ycA==
+jest-config@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-29.2.2.tgz#bf98623a46454d644630c1f0de8bba3f495c2d59"
+  integrity sha512-Q0JX54a5g1lP63keRfKR8EuC7n7wwny2HoTRDb8cx78IwQOiaYUVZAdjViY3WcTxpR02rPUpvNVmZ1fkIlZPcw==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/test-sequencer" "^29.2.1"
+    "@jest/test-sequencer" "^29.2.2"
     "@jest/types" "^29.2.1"
-    babel-jest "^29.2.1"
+    babel-jest "^29.2.2"
     chalk "^4.0.0"
     ci-info "^3.2.0"
     deepmerge "^4.2.2"
     glob "^7.1.3"
     graceful-fs "^4.2.9"
-    jest-circus "^29.2.1"
-    jest-environment-node "^29.2.1"
+    jest-circus "^29.2.2"
+    jest-environment-node "^29.2.2"
     jest-get-type "^29.2.0"
     jest-regex-util "^29.2.0"
-    jest-resolve "^29.2.1"
-    jest-runner "^29.2.1"
+    jest-resolve "^29.2.2"
+    jest-runner "^29.2.2"
     jest-util "^29.2.1"
-    jest-validate "^29.2.1"
+    jest-validate "^29.2.2"
     micromatch "^4.0.4"
     parse-json "^5.2.0"
     pretty-format "^29.2.1"
@@ -2669,30 +2735,30 @@ jest-each@^29.2.1:
     jest-util "^29.2.1"
     pretty-format "^29.2.1"
 
-jest-environment-jsdom@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.2.1.tgz#5bfbbc52a74b333c7e69ff3a4f540af850a7a718"
-  integrity sha512-MipBdmrjgzEdQMkK7b7wBShOfv1VqO6FVwa9S43bZwKYLC4dlWnPiCgNpZX3ypNEpJO8EMpMhg4HrUkWUZXGiw==
+jest-environment-jsdom@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-29.2.2.tgz#1e2d9f1f017fbaa7362a83e670b569158b4b8527"
+  integrity sha512-5mNtTcky1+RYv9kxkwMwt7fkzyX4EJUarV7iI+NQLigpV4Hz4sgfOdP4kOpCHXbkRWErV7tgXoXLm2CKtucr+A==
   dependencies:
-    "@jest/environment" "^29.2.1"
-    "@jest/fake-timers" "^29.2.1"
+    "@jest/environment" "^29.2.2"
+    "@jest/fake-timers" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/jsdom" "^20.0.0"
     "@types/node" "*"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
     jest-util "^29.2.1"
     jsdom "^20.0.0"
 
-jest-environment-node@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.2.1.tgz#f90311d0f0e8ef720349f83c97a076e403f90665"
-  integrity sha512-PulFKwEMz6nTAdLUwglFKei3b/LixwlRiqTN6nvPE1JtrLtlnpd6LXnFI1NFHYJGlTmIWilMP2n9jEtPPKX50g==
+jest-environment-node@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-29.2.2.tgz#a64b272773870c3a947cd338c25fd34938390bc2"
+  integrity sha512-B7qDxQjkIakQf+YyrqV5dICNs7tlCO55WJ4OMSXsqz1lpI/0PmeuXdx2F7eU8rnPbRkUR/fItSSUh0jvE2y/tw==
   dependencies:
-    "@jest/environment" "^29.2.1"
-    "@jest/fake-timers" "^29.2.1"
+    "@jest/environment" "^29.2.2"
+    "@jest/fake-timers" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
     jest-util "^29.2.1"
 
 jest-get-type@^29.2.0:
@@ -2737,6 +2803,16 @@ jest-matcher-utils@^29.2.1:
     jest-get-type "^29.2.0"
     pretty-format "^29.2.1"
 
+jest-matcher-utils@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz#9202f8e8d3a54733266784ce7763e9a08688269c"
+  integrity sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^29.2.1"
+    jest-get-type "^29.2.0"
+    pretty-format "^29.2.1"
+
 jest-message-util@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-29.2.1.tgz#3a51357fbbe0cc34236f17a90d772746cf8d9193"
@@ -2752,10 +2828,10 @@ jest-message-util@^29.2.1:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.2.1.tgz#a0d361cffcb28184fa9c5443adbf591fa5759775"
-  integrity sha512-NDphaY/GqyQpTfnTZiTqqpMaw4Z0I7XnB7yBgrT6IwYrLGxpOhrejYr4ANY4YvO2sEGdd8Tx/6D0+WLQy7/qDA==
+jest-mock@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-29.2.2.tgz#9045618b3f9d27074bbcf2d55bdca6a5e2e8bca7"
+  integrity sha512-1leySQxNAnivvbcx0sCB37itu8f4OX2S/+gxLAV4Z62shT4r4dTG9tACDywUAEZoLSr36aYUTsVp3WKwWt4PMQ==
   dependencies:
     "@jest/types" "^29.2.1"
     "@types/node" "*"
@@ -2771,67 +2847,67 @@ jest-regex-util@^29.2.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-29.2.0.tgz#82ef3b587e8c303357728d0322d48bbfd2971f7b"
   integrity sha512-6yXn0kg2JXzH30cr2NlThF+70iuO/3irbaB4mh5WyqNIvLLP+B6sFdluO1/1RJmslyh/f9osnefECflHvTbwVA==
 
-jest-resolve-dependencies@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.2.1.tgz#8d717dd41dc615fef1d412d395ea3deccfb1b9fa"
-  integrity sha512-o3mUGX2j08usj1jIAIE8KmUVpqVAn54k80kI27ldbZf2oJn6eghhB6DvJxjrcH40va9CQgWTfU5f2Ag/MoUqgQ==
+jest-resolve-dependencies@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-29.2.2.tgz#1f444766f37a25f1490b5137408b6ff746a05d64"
+  integrity sha512-wWOmgbkbIC2NmFsq8Lb+3EkHuW5oZfctffTGvwsA4JcJ1IRk8b2tg+hz44f0lngvRTeHvp3Kyix9ACgudHH9aQ==
   dependencies:
     jest-regex-util "^29.2.0"
-    jest-snapshot "^29.2.1"
+    jest-snapshot "^29.2.2"
 
-jest-resolve@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.2.1.tgz#a4d2f76db88aeb6ec5f5453c9a40b52483d17799"
-  integrity sha512-1dJTW76Z9622Viq4yRcwBuEXuzGtE9B2kdl05RC8Om/lAzac9uEgC+M8Q5osVidbuBPmxm8wSrcItYhca2ZAtQ==
+jest-resolve@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-29.2.2.tgz#ad6436053b0638b41e12bbddde2b66e1397b35b5"
+  integrity sha512-3gaLpiC3kr14rJR3w7vWh0CBX2QAhfpfiQTwrFPvVrcHe5VUBtIXaR004aWE/X9B2CFrITOQAp5gxLONGrk6GA==
   dependencies:
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     jest-haste-map "^29.2.1"
     jest-pnp-resolver "^1.2.2"
     jest-util "^29.2.1"
-    jest-validate "^29.2.1"
+    jest-validate "^29.2.2"
     resolve "^1.20.0"
     resolve.exports "^1.1.0"
     slash "^3.0.0"
 
-jest-runner@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.2.1.tgz#885afe64661cb2f51f84c1b97afb713d1093c124"
-  integrity sha512-PojFI+uVhQ4u4YZKCN/a3yU0/l/pJJXhq1sW3JpCp8CyvGBYGddRFPKZ1WihApusxqWRTHjBJmGyPWv6Av2lWA==
+jest-runner@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-29.2.2.tgz#6b5302ed15eba8bf05e6b14d40f1e8d469564da3"
+  integrity sha512-1CpUxXDrbsfy9Hr9/1zCUUhT813kGGK//58HeIw/t8fa/DmkecEwZSWlb1N/xDKXg3uCFHQp1GCvlSClfImMxg==
   dependencies:
     "@jest/console" "^29.2.1"
-    "@jest/environment" "^29.2.1"
+    "@jest/environment" "^29.2.2"
     "@jest/test-result" "^29.2.1"
-    "@jest/transform" "^29.2.1"
+    "@jest/transform" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
     chalk "^4.0.0"
-    emittery "^0.10.2"
+    emittery "^0.13.1"
     graceful-fs "^4.2.9"
     jest-docblock "^29.2.0"
-    jest-environment-node "^29.2.1"
+    jest-environment-node "^29.2.2"
     jest-haste-map "^29.2.1"
     jest-leak-detector "^29.2.1"
     jest-message-util "^29.2.1"
-    jest-resolve "^29.2.1"
-    jest-runtime "^29.2.1"
+    jest-resolve "^29.2.2"
+    jest-runtime "^29.2.2"
     jest-util "^29.2.1"
-    jest-watcher "^29.2.1"
+    jest-watcher "^29.2.2"
     jest-worker "^29.2.1"
     p-limit "^3.1.0"
     source-map-support "0.5.13"
 
-jest-runtime@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.2.1.tgz#62e3a23c33710ae4d9c3304dda851a5fb225b574"
-  integrity sha512-PSQ880OoIW9y8E6/jjhGn3eQNgNc6ndMzCZaKqy357bv7FqCfSyYepu3yDC6Sp1Vkt+GhP2M/PVgldS2uZSFZg==
+jest-runtime@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-29.2.2.tgz#4068ee82423769a481460efd21d45a8efaa5c179"
+  integrity sha512-TpR1V6zRdLynckKDIQaY41od4o0xWL+KOPUCZvJK2bu5P1UXhjobt5nJ2ICNeIxgyj9NGkO0aWgDqYPVhDNKjA==
   dependencies:
-    "@jest/environment" "^29.2.1"
-    "@jest/fake-timers" "^29.2.1"
-    "@jest/globals" "^29.2.1"
+    "@jest/environment" "^29.2.2"
+    "@jest/fake-timers" "^29.2.2"
+    "@jest/globals" "^29.2.2"
     "@jest/source-map" "^29.2.0"
     "@jest/test-result" "^29.2.1"
-    "@jest/transform" "^29.2.1"
+    "@jest/transform" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
     chalk "^4.0.0"
@@ -2841,18 +2917,18 @@ jest-runtime@^29.2.1:
     graceful-fs "^4.2.9"
     jest-haste-map "^29.2.1"
     jest-message-util "^29.2.1"
-    jest-mock "^29.2.1"
+    jest-mock "^29.2.2"
     jest-regex-util "^29.2.0"
-    jest-resolve "^29.2.1"
-    jest-snapshot "^29.2.1"
+    jest-resolve "^29.2.2"
+    jest-snapshot "^29.2.2"
     jest-util "^29.2.1"
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
-jest-snapshot@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.2.1.tgz#f3843b3099c8fec7e6218dea18cc506f10ea5d30"
-  integrity sha512-KZdLD7iEz5M4ZYd+ezZ/kk73z+DtNbk/yJ4Qx7408Vb0CCuclJIZPa/HmIwSsCfIlOBNcYTKufr7x/Yv47oYlg==
+jest-snapshot@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.2.2.tgz#1016ce60297b77382386bad561107174604690c2"
+  integrity sha512-GfKJrpZ5SMqhli3NJ+mOspDqtZfJBryGA8RIBxF+G+WbDoC7HCqKaeAss4Z/Sab6bAW11ffasx8/vGsj83jyjA==
   dependencies:
     "@babel/core" "^7.11.6"
     "@babel/generator" "^7.7.2"
@@ -2860,19 +2936,19 @@ jest-snapshot@^29.2.1:
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.3.3"
-    "@jest/expect-utils" "^29.2.1"
-    "@jest/transform" "^29.2.1"
+    "@jest/expect-utils" "^29.2.2"
+    "@jest/transform" "^29.2.2"
     "@jest/types" "^29.2.1"
     "@types/babel__traverse" "^7.0.6"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^29.2.1"
+    expect "^29.2.2"
     graceful-fs "^4.2.9"
     jest-diff "^29.2.1"
     jest-get-type "^29.2.0"
     jest-haste-map "^29.2.1"
-    jest-matcher-utils "^29.2.1"
+    jest-matcher-utils "^29.2.2"
     jest-message-util "^29.2.1"
     jest-util "^29.2.1"
     natural-compare "^1.4.0"
@@ -2891,10 +2967,10 @@ jest-util@^29.0.0, jest-util@^29.2.1:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
-jest-validate@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.2.1.tgz#db814ce12c4c7e4746044922762e56eb177d066c"
-  integrity sha512-DZVX5msG6J6DL5vUUw+++6LEkXUsPwB5R7fsfM7BXdz2Ipr0Ib046ak+8egrwAR++pvSM/5laxLK977ieIGxkQ==
+jest-validate@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.2.2.tgz#e43ce1931292dfc052562a11bc681af3805eadce"
+  integrity sha512-eJXATaKaSnOuxNfs8CLHgdABFgUrd0TtWS8QckiJ4L/QVDF4KVbZFBBOwCBZHOS0Rc5fOxqngXeGXE3nGQkpQA==
   dependencies:
     "@jest/types" "^29.2.1"
     camelcase "^6.2.0"
@@ -2903,17 +2979,17 @@ jest-validate@^29.2.1:
     leven "^3.1.0"
     pretty-format "^29.2.1"
 
-jest-watcher@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.2.1.tgz#1cb91f8aa9e77b1332af139944ad65e51430d7c3"
-  integrity sha512-7jFaHUaRq50l4w/f6RuY713bvI5XskMmjWCE54NGYcY74fLkShS8LucXJke1QfGnwDSCoIqGnGGGKPwdaBYz2Q==
+jest-watcher@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-29.2.2.tgz#7093d4ea8177e0a0da87681a9e7b09a258b9daf7"
+  integrity sha512-j2otfqh7mOvMgN2WlJ0n7gIx9XCMWntheYGlBK7+5g3b1Su13/UAK7pdKGyd4kDlrLwtH2QPvRv5oNIxWvsJ1w==
   dependencies:
     "@jest/test-result" "^29.2.1"
     "@jest/types" "^29.2.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    emittery "^0.10.2"
+    emittery "^0.13.1"
     jest-util "^29.2.1"
     string-length "^4.0.1"
 
@@ -2927,15 +3003,15 @@ jest-worker@^29.2.1:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.2.1.tgz#352ec0b81a0e436691d546d984cd7d8f72ffd26a"
-  integrity sha512-K0N+7rx+fv3Us3KhuwRSJt55MMpZPs9Q3WSO/spRZSnsalX8yEYOTQ1PiSN7OvqzoRX4JEUXCbOJRlP4n8m5LA==
+jest@^29.2.2:
+  version "29.2.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.2.2.tgz#24da83cbbce514718acd698926b7679109630476"
+  integrity sha512-r+0zCN9kUqoON6IjDdjbrsWobXM/09Nd45kIPRD8kloaRh1z5ZCMdVsgLXGxmlL7UpAJsvCYOQNO+NjvG/gqiQ==
   dependencies:
-    "@jest/core" "^29.2.1"
+    "@jest/core" "^29.2.2"
     "@jest/types" "^29.2.1"
     import-local "^3.0.2"
-    jest-cli "^29.2.1"
+    jest-cli "^29.2.2"
 
 js-sdsl@^4.1.4:
   version "4.1.5"
@@ -3119,6 +3195,11 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
 make-dir@^3.0.0:
   version "3.1.0"
@@ -3507,6 +3588,15 @@ prettier@^2.7.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 pretty-format@^29.0.0, pretty-format@^29.2.1:
   version "29.2.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.2.1.tgz#86e7748fe8bbc96a6a4e04fa99172630907a9611"
@@ -3561,10 +3651,22 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"


### PR DESCRIPTION
## 테스트 코드 구조 

### 1. TodoList render
동작 : render
point : 화면 진입 시 요소들이 잘 렌더링 되었는가?

- 타이틀이 화면에 노출되었는가
- count가 0으로 화면에 노출되었는가
- add input의 value 값이 빈 값으로 화면에 노출되었는가
- add button이 화면에 노출되었는가
- 화면에 노출된 todo들의 갯수가 0개인가


### 2. Todo 추가
동작 : input 값 입력 → Enter or Add 버튼 click
point : todo 추가 후 화면의 움직임

- count가 todo의 갯수만큼 화면에 노출되었는가
- add input의 value 값이 빈 값으로 화면에 노출되었는가
- 화면에 노출된 todo들의 갯수가 올바르게 노출되었는가
- 새로 추가한 todo의 텍스트가 방금 input에 입력한 텍스트와 일치한가


### 3. Todo 삭제
동작 : todo의 삭제 버튼 click
point : todo 삭제 후 화면의 움직임

- count가 올바르게 노출되는가
- 화면에 노출된 todo 갯수가 올바른가
- 삭제한 Todo가 화면에 노출되지 않는가


### 4. Todo 수정
동작 : todo의 edit 버튼 click
point : todo edit 버튼 클릭 후 화면의 움직임

- 화면에 todo 수정 화면이 노출되는가
- edit input에 value 값이 해당 todo의 text로 되어있는가

동작 : edit input clear → edit input 값 입력 → Enter or Save 버튼 click
point : todo 값 수정 후 화면의 움직임

- todo 수정 화면이 비노출되는가
- 수정한 텍스트가 반영되었는가


### 5. Todo 상태 변경
동작 : todo를 toggle click
point : todo 상태 변경 후 화면의 움직임

- completed count가 올바르게 노출되는가
- 아이콘의 클래스명이 올바르게 노출되는가

---

## description

처음엔 각 컴포넌트별로 쪼개서 테스트를 작성하려고 시도했는데,
너무 잘게 쪼개다보니 컴포넌트간의 구분선에 따라 테스트 범위도 너무 한정되어 버리고,
(TodoHeader에서 totalNumber를 확인하려면 todo items의 갯수를 알아야하는 등의 문제)
사용자의 입장에서의 테스트보다는 state나 props 상태값에 집중하게 됨
→
TodoList의 기본 기능 (CRUD)과 화면의 동작에 집중해 하나의 테스트 파일로 작성함
(동작과 화면의 연동 움직임에 초점)



## 참고 링크
- [jest Docs](https://jestjs.io/docs/getting-started)
- [testing-library Docs](https://testing-library.com/docs/user-event/intro/)
- [TypeScript에서 RTL로 선언적인 테스트 코드 작성하기](https://bokjiho.medium.com/typescript%EC%97%90%EC%84%9C-rtl%EB%A1%9C-%EC%84%A0%EC%96%B8%EC%A0%81%EC%9D%B8-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C-%EC%9E%91%EC%84%B1%ED%95%98%EA%B8%B0-edb0ba29f73b)
- [TodoList Test Code Example](https://codesandbox.io/s/2489y40n6n?file=/src/__tests__/TodoList.test.js:3365-3449)